### PR TITLE
dr_factor upgrades

### DIFF
--- a/R/dr_factor.R
+++ b/R/dr_factor.R
@@ -105,7 +105,6 @@ dr_factor <- function(.data, corrFactor, dateVar, timeVar, tz = NULL, keepDateTi
     dplyr::mutate(dateTimePOSIX =
                     lubridate::parse_date_time(dateTime, orders = c("ymd HMS", "dmy HMS", "mdy HMS"),
                                                tz = tz)) %>%
-    dplyr::mutate(dateTimePOSIX = base::as.POSIXct(dateTime, format = dayTimeFormat)) %>%
     dplyr::mutate(dateTimePOSIX = base::as.numeric(dateTimePOSIX)) %>%
     dplyr::mutate(totTime = utils::tail(dateTimePOSIX, n=1) - utils::head(dateTimePOSIX, n=1)) %>%
     dplyr::mutate(!!corrFactor := (dateTimePOSIX - utils::head(dateTimePOSIX, n=1)) / totTime) -> .data

--- a/R/dr_factor.R
+++ b/R/dr_factor.R
@@ -6,13 +6,16 @@
 #'     that the instrument had been deployed. They are used in the equations for both the one-point and two-point
 #'     drift corrections.
 #'
-#' @usage dr_factor(.data, corrFactor, dateVar, timeVar, tz = NULL, keepDateTime = TRUE)
+#' @usage dr_factor(.data, corrFactor, dateVar, timeVar, tz = NULL,
+#'     format = c("MDY", "YMD"), keepDateTime = TRUE)
 #'
 #' @param .data A tbl
 #' @param corrFactor New variable name for correction factor data
 #' @param dateVar Name of variable containing date data
 #' @param timeVar Name of variable containing time data
 #' @param tz String name of timezone, defaults to system's timezone
+#' @param format Either "MDY" or "YMD" for \code{dateVar} -
+#'     \strong{\emph{deprecated as of \code{driftR} v1.1}}
 #' @param keepDateTime A logical statement to keep an intermediate dateTime variable
 #'
 #' @return An object of the same class as \code{.data} with the new correction factor variable added
@@ -36,13 +39,18 @@
 #' dr_factor(testData, corrFactor = corrFac, dateVar = Date, timeVar = Time, keepDateTime = TRUE)
 #'
 #' @export
-dr_factor <- function(.data, corrFactor, dateVar, timeVar, tz = NULL, keepDateTime = TRUE) {
+dr_factor <- function(.data, corrFactor, dateVar, timeVar, tz = NULL, format = c("MDY", "YMD"), keepDateTime = TRUE) {
 
   # save parameters to list
   paramList <- as.list(match.call())
 
   # To prevent NOTE from R CMD check 'no visible binding for global variable'
   dateTime = totTime = dateTimePOSIX = NULL
+
+  # check for deprecated paramater
+  if (!missing(format)) {
+    warning("Argument format is deprecated; dates and times are now automatically parsed as of v1.1.", call. = FALSE)
+  }
 
   # check for missing parameters
   if (missing(corrFactor)) {

--- a/R/dr_factor.R
+++ b/R/dr_factor.R
@@ -6,14 +6,13 @@
 #'     that the instrument had been deployed. They are used in the equations for both the one-point and two-point
 #'     drift corrections.
 #'
-#' @usage dr_factor(.data, corrFactor, dateVar, timeVar,
-#'                  format = c("MDY", "YMD"), keepDateTime = TRUE)
+#' @usage dr_factor(.data, corrFactor, dateVar, timeVar, tz = NULL, keepDateTime = TRUE)
 #'
 #' @param .data A tbl
 #' @param corrFactor New variable name for correction factor data
 #' @param dateVar Name of variable containing date data
 #' @param timeVar Name of variable containing time data
-#' @param format Either "MDY" or "YMD" for \code{dateVar}
+#' @param tz String name of timezone, defaults to system's timezone
 #' @param keepDateTime A logical statement to keep an intermediate dateTime variable
 #'
 #' @return An object of the same class as \code{.data} with the new correction factor variable added
@@ -34,22 +33,13 @@
 #'    stringsAsFactors = FALSE
 #'  )
 #'
-#' dr_factor(testData, corrFactor = corrFac, dateVar = Date, timeVar = Time,
-#'           format = "MDY", keepDateTime = TRUE)
+#' dr_factor(testData, corrFactor = corrFac, dateVar = Date, timeVar = Time, keepDateTime = TRUE)
 #'
 #' @export
-dr_factor <- function(.data, corrFactor, dateVar, timeVar, format = c("MDY", "YMD"), keepDateTime = TRUE) {
+dr_factor <- function(.data, corrFactor, dateVar, timeVar, tz = NULL, keepDateTime = TRUE) {
 
   # save parameters to list
   paramList <- as.list(match.call())
-
-  # check if fostmat is quoted
-  if (!is.character(paramList$format)) {
-    if (is.null(paramList$format)) {
-      stop('A format - either MDY or YMD - must be specified')
-    } else if (!is.null(paramList$format))
-      stop('It appears that the format parameter is not quoted')
-  }
 
   # To prevent NOTE from R CMD check 'no visible binding for global variable'
   dateTime = totTime = dateTimePOSIX = NULL
@@ -102,22 +92,19 @@ dr_factor <- function(.data, corrFactor, dateVar, timeVar, format = c("MDY", "YM
                     var = corrFactor))
   }
 
-  # check format
-  if(format %nin% c("MDY", "YMD")) {
-    stop(glue::glue('The date-time format {format} is invalid - format should be MDY or YMD'))
-  }
+  # prepare time zone
+  if (is.null(tz)){
 
-  # set format
-  if (format == "MDY"){
-    dayTimeFormat <- "%m/%d/%Y %H:%M:%S"
-  }
-  else if (format == "YMD"){
-    dayTimeFormat <- "%Y-%m-%d %H:%M:%S"
+    tz <- Sys.timezone()
+
   }
 
   # concatenate date and time, apply date-time format, and calculate correction factor
   .data %>%
-    dplyr::mutate(dateTime = stringr::str_c(!!date, !!time, sep = " ", collapse = NULL)) %>%
+    dplyr::mutate(dateTime := stringr::str_c(!!date, !!time, sep = " ")) %>%
+    dplyr::mutate(dateTimePOSIX =
+                    lubridate::parse_date_time(dateTime, orders = c("ymd HMS", "dmy HMS", "mdy HMS"),
+                                               tz = tz)) %>%
     dplyr::mutate(dateTimePOSIX = base::as.POSIXct(dateTime, format = dayTimeFormat)) %>%
     dplyr::mutate(dateTimePOSIX = base::as.numeric(dateTimePOSIX)) %>%
     dplyr::mutate(totTime = utils::tail(dateTimePOSIX, n=1) - utils::head(dateTimePOSIX, n=1)) %>%

--- a/man/dr_factor.Rd
+++ b/man/dr_factor.Rd
@@ -4,8 +4,8 @@
 \alias{dr_factor}
 \title{Creating correction factors}
 \usage{
-dr_factor(.data, corrFactor, dateVar, timeVar,
-                 format = c("MDY", "YMD"), keepDateTime = TRUE)
+dr_factor(.data, corrFactor, dateVar, timeVar, tz = NULL,
+    format = c("MDY", "YMD"), keepDateTime = TRUE)
 }
 \arguments{
 \item{.data}{A tbl}
@@ -16,7 +16,10 @@ dr_factor(.data, corrFactor, dateVar, timeVar,
 
 \item{timeVar}{Name of variable containing time data}
 
-\item{format}{Either "MDY" or "YMD" for \code{dateVar}}
+\item{tz}{String name of timezone, defaults to system's timezone}
+
+\item{format}{Either "MDY" or "YMD" for \code{dateVar} -
+\strong{\emph{deprecated as of \code{driftR} v1.1}}}
 
 \item{keepDateTime}{A logical statement to keep an intermediate dateTime variable}
 }
@@ -41,8 +44,7 @@ testData <- data.frame(
    stringsAsFactors = FALSE
  )
 
-dr_factor(testData, corrFactor = corrFac, dateVar = Date, timeVar = Time,
-          format = "MDY", keepDateTime = TRUE)
+dr_factor(testData, corrFactor = corrFac, dateVar = Date, timeVar = Time, keepDateTime = TRUE)
 
 }
 \seealso{

--- a/tests/testthat/test_factor.R
+++ b/tests/testthat/test_factor.R
@@ -8,16 +8,16 @@ result <- dr_readSonde(system.file("extdata", "rawData.csv", package = "driftR")
 # test inputs ------------------------------------------------
 
 test_that("quoted variables do not cause errors", {
-  expect_error(dr_factor(result, corrFactor = "factors", dateVar = Date, timeVar = Time, format = "MDY", keepDateTime = TRUE), NA)
-  expect_error(dr_factor(result, corrFactor = factors, dateVar = "Date", timeVar = Time, format = "MDY", keepDateTime = TRUE), NA)
-  expect_error(dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = "Time", format = "MDY", keepDateTime = TRUE), NA)
-  expect_error(dr_factor(result, corrFactor = "factors", dateVar = "Date", timeVar = "Time", format = "MDY", keepDateTime = TRUE), NA)
+  expect_error(dr_factor(result, corrFactor = "factors", dateVar = Date, timeVar = Time, keepDateTime = TRUE), NA)
+  expect_error(dr_factor(result, corrFactor = factors, dateVar = "Date", timeVar = Time, keepDateTime = TRUE), NA)
+  expect_error(dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = "Time", keepDateTime = TRUE), NA)
+  expect_error(dr_factor(result, corrFactor = "factors", dateVar = "Date", timeVar = "Time", keepDateTime = TRUE), NA)
 })
 
 ## the tests above did not catch that the function was failing without an error - it would create
 ## the new vector but it would be all NAs
 
-result4 <- dr_factor(result, corrFactor = factors, dateVar = "Date", timeVar = "Time", format = "MDY", keepDateTime = FALSE)
+result4 <- dr_factor(result, corrFactor = factors, dateVar = "Date", timeVar = "Time", keepDateTime = FALSE)
 
 test_that("quoted variables do not cause errors", {
   expect_false(is.na(result4$factors[1]))
@@ -30,35 +30,26 @@ test_that("quoted variables do not cause errors", {
 # test errors ------------------------------------------------
 
 test_that("input errors trigged - missing parameters", {
-  expect_error(dr_factor(result, dateVar = foo, timeVar = Time, format = "MDY", keepDateTime = TRUE),
+  expect_error(dr_factor(result, dateVar = foo, timeVar = Time, keepDateTime = TRUE),
                "A new variable name must be specified for corrFactor")
-  expect_error(dr_factor(result, corrFactor = factors, timeVar = bar, format = "MDY", keepDateTime = TRUE),
+  expect_error(dr_factor(result, corrFactor = factors, timeVar = bar, keepDateTime = TRUE),
                "An existing variable with date data must be specified for dateVar")
-  expect_error(dr_factor(result, corrFactor = factors, dateVar = Date, format = "MDY", keepDateTime = TRUE),
+  expect_error(dr_factor(result, corrFactor = factors, dateVar = Date, keepDateTime = TRUE),
                "An existing variable with time data must be specified for timeVar")
-  expect_error(dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, keepDateTime = TRUE),
-               "A format - either MDY or YMD - must be specified")
 })
 
 test_that("input errors trigged - variables invalid", {
-  expect_error(dr_factor(result, corrFactor = factors, dateVar = foo, timeVar = Time, format = "MDY", keepDateTime = TRUE),
+  expect_error(dr_factor(result, corrFactor = factors, dateVar = foo, timeVar = Time, keepDateTime = TRUE),
                "Variable foo, given for dateVar, cannot be found in the given data frame")
-  expect_error(dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = bar, format = "MDY", keepDateTime = TRUE),
+  expect_error(dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = bar, keepDateTime = TRUE),
                "Variable bar, given for timeVar, cannot be found in the given data frame")
-  expect_error(dr_factor(result, corrFactor = Date, dateVar = Date, timeVar = Time, format = "MDY", keepDateTime = TRUE),
+  expect_error(dr_factor(result, corrFactor = Date, dateVar = Date, timeVar = Time, keepDateTime = TRUE),
                "A variable named Date, given for corrFactor, already exists in the given data frame")
-})
-
-test_that("input errors trigged - format invalid", {
-  expect_error(dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, format = "foo", keepDateTime = TRUE),
-               "The date-time format foo is invalid - format should be MDY or YMD")
-  expect_error(dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, format = foo, keepDateTime = TRUE),
-               "It appears that the format parameter is not quoted")
 })
 
 # test results ------------------------------------------------
 
-result <- dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, format = "MDY", keepDateTime = TRUE)
+result <- dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, keepDateTime = TRUE)
 
 test_that("creating correction factors", {
   expect_equal(result$factors, test_data1$corrFactors)
@@ -80,8 +71,8 @@ testData3 <- data.frame(
   stringsAsFactors = FALSE
 )
 
-result2 <- dr_factor(testData2, corrFactor = factors, dateVar = Date, timeVar = Time, format = "YMD", keepDateTime = TRUE)
-result3 <- dr_factor(testData3, corrFactor = factors, dateVar = Date, timeVar = Time, format = "MDY", keepDateTime = TRUE)
+result2 <- dr_factor(testData2, corrFactor = factors, dateVar = Date, timeVar = Time, keepDateTime = TRUE)
+result3 <- dr_factor(testData3, corrFactor = factors, dateVar = Date, timeVar = Time, keepDateTime = TRUE)
 
 test_that("creating correction factors", {
   expect_equal(result2$factors, result3$factors)

--- a/tests/testthat/test_factor.R
+++ b/tests/testthat/test_factor.R
@@ -47,6 +47,13 @@ test_that("input errors trigged - variables invalid", {
                "A variable named Date, given for corrFactor, already exists in the given data frame")
 })
 
+test_that("input errors trigged - format is deprecated", {
+  expect_warning(dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, format = "MDY"),
+                 "Argument format is deprecated; dates and times are now automatically parsed as of v1.1.")
+  expect_warning(dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, format = "YMD"),
+                 "Argument format is deprecated; dates and times are now automatically parsed as of v1.1.")
+})
+
 # test results ------------------------------------------------
 
 result <- dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, keepDateTime = TRUE)

--- a/tests/testthat/test_onePoint.R
+++ b/tests/testthat/test_onePoint.R
@@ -4,7 +4,7 @@ context("test one-point correction process")
 
 test_data1 <- read.csv(system.file("extdata", "sondeClean.csv", package = "driftR"), stringsAsFactors = FALSE)
 result <- dr_readSonde(system.file("extdata", "rawData.csv", package = "driftR"), defineVar = TRUE)
-result <- dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, format = "MDY", keepDateTime = TRUE)
+result <- dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, keepDateTime = TRUE)
 
 # test inputs ------------------------------------------------
 

--- a/tests/testthat/test_twoPoint.R
+++ b/tests/testthat/test_twoPoint.R
@@ -4,7 +4,7 @@ context("test two-point correction process")
 
 test_data1 <- read.csv(system.file("extdata", "sondeClean.csv", package = "driftR"), stringsAsFactors = FALSE)
 result <- dr_readSonde(system.file("extdata", "rawData.csv", package = "driftR"), defineVar = TRUE)
-result <- dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, format = "MDY", keepDateTime = TRUE)
+result <- dr_factor(result, corrFactor = factors, dateVar = Date, timeVar = Time, keepDateTime = TRUE)
 
 # test inputs ------------------------------------------------
 


### PR DESCRIPTION
This branch includes a refactored version of `dr_factor` that deprecates the `format` argument in factor of automatic date parsing using `lubridate::parse_date_time`. All of the unit tests have also been adjusted to remove references to the `format` argument, except for one pair of tests that tests the warning given to users if they use the `format` argument now. This fixes issue #11 